### PR TITLE
[ENH] add setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 obj
 *.so
 *.pyc
+*.o
+
+stingycd.egg-info/*

--- a/__init__.py
+++ b/__init__.py
@@ -1,1 +1,0 @@
-from _lasso_problem import LassoProblem

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,35 @@
+import os
+
+from distutils.core import setup, Extension
+
+
+source_list = ["src/%s" % f for f in os.listdir("src")
+               if f.endswith("cpp")]
+
+ext = Extension("stingycd.cd",
+                include_dirs=["src"],
+                extra_compile_args=['-O3'],
+                sources=source_list)
+
+descr = 'TODO'
+
+version = '0.1'
+
+DISTNAME = 'stingycd'
+DESCRIPTION = descr
+MAINTAINER = 'T. B. Johnson/Mathurin Massias'
+MAINTAINER_EMAIL = 'TODO'
+DOWNLOAD_URL = 'https://github.com/tbjohns/singycd.git'
+VERSION = version
+
+setup(name='stingycd',
+      version=VERSION,
+      description=DESCRIPTION,
+      package_dir={"stingycd": "stingycd"},
+      packages=["stingycd"],
+      ext_modules=[ext],
+      long_description=open('README.md').read(),
+      maintainer=MAINTAINER,
+      maintainer_email=MAINTAINER_EMAIL,
+      download_url=DOWNLOAD_URL,
+      )

--- a/stingycd/__init__.py
+++ b/stingycd/__init__.py
@@ -1,0 +1,1 @@
+from ._lasso_problem import LassoProblem

--- a/stingycd/_lasso_problem.py
+++ b/stingycd/_lasso_problem.py
@@ -5,7 +5,7 @@ import _ctypes
 from scipy import sparse
 
 current_dir = os.path.abspath(os.path.dirname(__file__))
-lib = np.ctypeslib.load_library("cd.so", current_dir)
+lib = np.ctypeslib.load_library("cd", current_dir)
 
 lib.CD_new.restype = ctypes.POINTER(ctypes.c_void_p)
 lib.CD_set_A_dense.restype = None


### PR DESCRIPTION
bypasses the use of make
`pip install -e  .` makes the code runnable from anywhere on the system.